### PR TITLE
Add retro terminal landing page design

### DIFF
--- a/src/components/Welcome.astro
+++ b/src/components/Welcome.astro
@@ -1,210 +1,210 @@
 ---
-import astroLogo from '../assets/astro.svg';
-import background from '../assets/background.svg';
 ---
 
-<div id="container">
-	<img id="background" src={background.src} alt="" fetchpriority="high" />
-	<main>
-		<section id="hero">
-			<a href="https://astro.build"
-				><img src={astroLogo.src} width="115" height="48" alt="Astro Homepage" /></a
-			>
-			<h1>
-				To get started, open the <code><pre>src/pages</pre></code> directory in your project.
-			</h1>
-			<section id="links">
-				<a class="button" href="https://docs.astro.build">Read our docs</a>
-				<a href="https://astro.build/chat"
-					>Join our Discord <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 127.14 96.36"
-						><path
-							fill="currentColor"
-							d="M107.7 8.07A105.15 105.15 0 0 0 81.47 0a72.06 72.06 0 0 0-3.36 6.83 97.68 97.68 0 0 0-29.11 0A72.37 72.37 0 0 0 45.64 0a105.89 105.89 0 0 0-26.25 8.09C2.79 32.65-1.71 56.6.54 80.21a105.73 105.73 0 0 0 32.17 16.15 77.7 77.7 0 0 0 6.89-11.11 68.42 68.42 0 0 1-10.85-5.18c.91-.66 1.8-1.34 2.66-2a75.57 75.57 0 0 0 64.32 0c.87.71 1.76 1.39 2.66 2a68.68 68.68 0 0 1-10.87 5.19 77 77 0 0 0 6.89 11.1 105.25 105.25 0 0 0 32.19-16.14c2.64-27.38-4.51-51.11-18.9-72.15ZM42.45 65.69C36.18 65.69 31 60 31 53s5-12.74 11.43-12.74S54 46 53.89 53s-5.05 12.69-11.44 12.69Zm42.24 0C78.41 65.69 73.25 60 73.25 53s5-12.74 11.44-12.74S96.23 46 96.12 53s-5.04 12.69-11.43 12.69Z"
-						></path></svg
-					>
-				</a>
-			</section>
-		</section>
-	</main>
-
-	<a href="https://astro.build/blog/astro-5/" id="news" class="box">
-		<svg width="32" height="32" fill="none" xmlns="http://www.w3.org/2000/svg"
-			><path
-				d="M24.667 12c1.333 1.414 2 3.192 2 5.334 0 4.62-4.934 5.7-7.334 12C18.444 28.567 18 27.456 18 26c0-4.642 6.667-7.053 6.667-14Zm-5.334-5.333c1.6 1.65 2.4 3.43 2.4 5.333 0 6.602-8.06 7.59-6.4 17.334C13.111 27.787 12 25.564 12 22.666c0-4.434 7.333-8 7.333-16Zm-6-5.333C15.111 3.555 16 5.556 16 7.333c0 8.333-11.333 10.962-5.333 22-3.488-.774-6-4-6-8 0-8.667 8.666-10 8.666-20Z"
-				fill="#111827"></path></svg
-		>
-		<h2>What's New in Astro 5.0?</h2>
-		<p>
-			From content layers to server islands, click to learn more about the new features and
-			improvements in Astro 5.0
-		</p>
-	</a>
+<div id="terminal">
+	<div class="terminal-header">
+		<div class="terminal-controls">
+			<span class="control close"></span>
+			<span class="control minimize"></span>
+			<span class="control maximize"></span>
+		</div>
+		<div class="terminal-title">Terminal</div>
+	</div>
+	<div class="terminal-content">
+		<div class="terminal-line">
+			<span class="prompt">astro@retro:~$</span>
+			<span class="command">welcome</span>
+		</div>
+		<div class="terminal-output">
+			<div class="ascii-art">
+				<pre>
+    ___   _____ _____ ____   ___  
+   /   \ |  ___|_   _|  _ \ / _ \ 
+  / /\ / | |_    | | | |_) | | | |
+ / /_//  |  _|   | | |  _ <| |_| |
+/___,'   |_|     |_| |_| \_\\___/ 
+                                  
+              Terminal v1.0        
+			</pre>
+			</div>
+			<div class="welcome-text">
+				<p>Welcome to the Astro Retro Terminal!</p>
+				<p>System initialized successfully...</p>
+				<p>Ready for commands.</p>
+			</div>
+			<div class="commands">
+				<div class="command-line">
+					<span class="prompt">astro@retro:~$</span>
+					<span class="command">ls projects</span>
+				</div>
+				<div class="output">
+					<a href="https://docs.astro.build" class="file-link">astro-docs/</a>
+					<a href="https://astro.build/chat" class="file-link">discord-chat/</a>
+				</div>
+			</div>
+			<div class="current-line">
+				<span class="prompt">astro@retro:~$</span>
+				<span class="cursor">█</span>
+			</div>
+		</div>
+	</div>
 </div>
 
 <style>
-	#background {
-		position: fixed;
-		top: 0;
-		left: 0;
-		width: 100%;
-		height: 100%;
-		z-index: -1;
-		filter: blur(100px);
+	#terminal {
+		font-family: 'Courier New', 'Liberation Mono', 'DejaVu Sans Mono', monospace;
+		background: #000;
+		color: #00ff00;
+		width: 90vw;
+		max-width: 800px;
+		margin: 20px auto;
+		border-radius: 8px;
+		box-shadow: 0 0 20px rgba(0, 255, 0, 0.3);
+		overflow: hidden;
+		border: 2px solid #333;
 	}
 
-	#container {
-		font-family: Inter, Roboto, 'Helvetica Neue', 'Arial Nova', 'Nimbus Sans', Arial, sans-serif;
-		height: 100%;
-	}
-
-	main {
-		height: 100%;
-		display: flex;
-		justify-content: center;
-	}
-
-	#hero {
-		display: flex;
-		align-items: start;
-		flex-direction: column;
-		justify-content: center;
-		padding: 16px;
-	}
-
-	h1 {
-		font-size: 22px;
-		margin-top: 0.25em;
-	}
-
-	#links {
-		display: flex;
-		gap: 16px;
-	}
-
-	#links a {
+	.terminal-header {
+		background: #2d2d2d;
+		padding: 8px 12px;
 		display: flex;
 		align-items: center;
-		padding: 10px 12px;
-		color: #111827;
-		text-decoration: none;
-		transition: color 0.2s;
+		border-bottom: 1px solid #444;
 	}
 
-	#links a:hover {
-		color: rgb(78, 80, 86);
+	.terminal-controls {
+		display: flex;
+		gap: 6px;
+		margin-right: 10px;
 	}
 
-	#links a svg {
-		height: 1em;
+	.control {
+		width: 12px;
+		height: 12px;
+		border-radius: 50%;
+	}
+
+	.control.close {
+		background: #ff5f57;
+	}
+
+	.control.minimize {
+		background: #ffbd2e;
+	}
+
+	.control.maximize {
+		background: #28ca42;
+	}
+
+	.terminal-title {
+		color: #ccc;
+		font-size: 14px;
+		font-weight: normal;
+	}
+
+	.terminal-content {
+		padding: 20px;
+		min-height: 400px;
+		background: #000;
+	}
+
+	.prompt {
+		color: #00ff00;
+		font-weight: bold;
+	}
+
+	.command {
+		color: #ffff00;
 		margin-left: 8px;
 	}
 
-	#links a.button {
-		color: white;
-		background: linear-gradient(83.21deg, #3245ff 0%, #bc52ee 100%);
-		box-shadow:
-			inset 0 0 0 1px rgba(255, 255, 255, 0.12),
-			inset 0 -2px 0 rgba(0, 0, 0, 0.24);
-		border-radius: 10px;
+	.terminal-line {
+		margin-bottom: 10px;
 	}
 
-	#links a.button:hover {
-		color: rgb(230, 230, 230);
-		box-shadow: none;
+	.ascii-art {
+		margin: 20px 0;
 	}
 
-	pre {
-		font-family:
-			ui-monospace, 'Cascadia Code', 'Source Code Pro', Menlo, Consolas, 'DejaVu Sans Mono',
-			monospace;
-		font-weight: normal;
-		background: linear-gradient(14deg, #d83333 0%, #f041ff 100%);
-		-webkit-background-clip: text;
-		-webkit-text-fill-color: transparent;
-		background-clip: text;
+	.ascii-art pre {
+		color: #00ffff;
+		font-size: 12px;
+		line-height: 1.2;
 		margin: 0;
+		text-shadow: 0 0 5px #00ffff;
 	}
 
-	h2 {
-		margin: 0 0 1em;
-		font-weight: normal;
-		color: #111827;
-		font-size: 20px;
+	.welcome-text {
+		margin: 20px 0;
 	}
 
-	p {
-		color: #4b5563;
+	.welcome-text p {
+		color: #00ff00;
+		margin: 8px 0;
 		font-size: 16px;
-		line-height: 24px;
-		letter-spacing: -0.006em;
-		margin: 0;
+		line-height: 1.4;
 	}
 
-	code {
-		display: inline-block;
-		background:
-			linear-gradient(66.77deg, #f3cddd 0%, #f5cee7 100%) padding-box,
-			linear-gradient(155deg, #d83333 0%, #f041ff 18%, #f5cee7 45%) border-box;
-		border-radius: 8px;
-		border: 1px solid transparent;
-		padding: 6px 8px;
+	.commands {
+		margin: 20px 0;
 	}
 
-	.box {
-		padding: 16px;
-		background: rgba(255, 255, 255, 1);
-		border-radius: 16px;
-		border: 1px solid white;
+	.command-line {
+		margin: 10px 0;
 	}
 
-	#news {
-		position: absolute;
-		bottom: 16px;
-		right: 16px;
-		max-width: 300px;
+	.output {
+		margin: 8px 0 0 20px;
+	}
+
+	.file-link {
+		color: #87ceeb;
 		text-decoration: none;
-		transition: background 0.2s;
-		backdrop-filter: blur(50px);
+		margin-right: 15px;
+		transition: color 0.2s, text-shadow 0.2s;
 	}
 
-	#news:hover {
-		background: rgba(255, 255, 255, 0.55);
+	.file-link:hover {
+		color: #00ffff;
+		text-shadow: 0 0 5px #00ffff;
 	}
 
-	@media screen and (max-height: 368px) {
-		#news {
-			display: none;
+	.current-line {
+		margin-top: 20px;
+	}
+
+	.cursor {
+		background: #00ff00;
+		color: #000;
+		animation: blink 1s infinite;
+	}
+
+	@keyframes blink {
+		0%, 50% {
+			opacity: 1;
+		}
+		51%, 100% {
+			opacity: 0;
 		}
 	}
 
 	@media screen and (max-width: 768px) {
-		#container {
-			display: flex;
-			flex-direction: column;
+		#terminal {
+			width: 95vw;
+			margin: 10px auto;
 		}
 
-		#hero {
-			display: block;
-			padding-top: 10%;
+		.terminal-content {
+			padding: 15px;
+			min-height: 300px;
 		}
 
-		#links {
-			flex-wrap: wrap;
+		.ascii-art pre {
+			font-size: 10px;
 		}
 
-		#links a.button {
-			padding: 14px 18px;
-		}
-
-		#news {
-			right: 16px;
-			left: 16px;
-			bottom: 2.5rem;
-			max-width: 100%;
-		}
-
-		h1 {
-			line-height: 1.5;
+		.welcome-text p {
+			font-size: 14px;
 		}
 	}
 </style>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -5,7 +5,7 @@
 		<meta name="viewport" content="width=device-width" />
 		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
 		<meta name="generator" content={Astro.generator} />
-		<title>Astro Basics</title>
+		<title>Retro Terminal</title>
 	</head>
 	<body>
 		<slot />
@@ -18,5 +18,11 @@
 		margin: 0;
 		width: 100%;
 		height: 100%;
+		background: #0d1117;
+		background-image: 
+			radial-gradient(circle at 25% 25%, #00ff0020 0%, transparent 50%),
+			radial-gradient(circle at 75% 75%, #00ffff15 0%, transparent 50%);
+		min-height: 100vh;
+		overflow-x: hidden;
 	}
 </style>


### PR DESCRIPTION
## Summary
- Transformed the default Astro landing page into a cool retro terminal interface
- Added authentic terminal window with macOS-style traffic light controls
- Implemented classic green-on-black color scheme with cyan and yellow accents
- Added ASCII art logo and blinking cursor animation

## Key Features
- **Terminal Window**: Complete with close/minimize/maximize controls
- **Retro Colors**: Classic green text on black background
- **ASCII Art**: Custom "RETRO" banner
- **Animations**: Blinking cursor for authenticity
- **Interactive Elements**: Terminal-style command prompts and file listings
- **Responsive Design**: Works well on mobile devices

## Test plan
- [ ] Verify the page loads correctly in the browser
- [ ] Check that all links (docs, Discord) work properly
- [ ] Test responsive design on mobile devices
- [ ] Confirm cursor blinking animation works
- [ ] Validate terminal styling appears correctly

🤖 Generated with [Claude Code](https://claude.ai/code)